### PR TITLE
Add workflows to build and publish the site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build site
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Build site
+        working-directory: src
+        run: |
+          # Set timezone to avoid issue with nektos/act
+          # https://github.com/nektos/act/issues/1853
+          TZ=UTC make html
+
+      - name: Upload site as build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: src/_build/html/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Build and deploy to gh-pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: observational-dev/oawiki/.github/workflows/build.yml@main
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download site
+        uses: actions/download-artifact@v3
+        with:
+          name: site
+          path: site
+
+      - name: Configure github pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload the site
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'site/'
+
+      - name: Deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR adds github workflows to 

- Automatically build the site on each PR - that way no PR that breaks the site will get merged unknowingly
- Automatically build the site and deploy when a PR gets merged to `main`