### PR TITLE
Fix wrong target branch for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Build and deploy to gh-pages
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/src/conf.py
+++ b/src/conf.py
@@ -44,4 +44,4 @@ suppress_warnings = [
 ]
 
 html_theme = "pydata_sphinx_theme"
-html_static_path = ['_static']
+# html_static_path = ['_static']


### PR DESCRIPTION
This PR fixes a broken workflow file, which was targeting the wrong branch. Also, I've commented out the `html_static_path` as there's nothing in there right now, and the build will fail if `_static/` doesn't exist when this option is configured. We can reenable it when needed.