### PR TITLE
shrink footer

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -44,4 +44,11 @@ suppress_warnings = [
 ]
 
 html_theme = "pydata_sphinx_theme"
+
+# by default, this has more, but we value brevity.
+html_theme_options = {
+  "footer_start": ["copyright"], 
+  "footer_end": ["sphinx-version"]
+}
+
 # html_static_path = ['_static']


### PR DESCRIPTION
Resolves #11 
Note that the footer is not sticky, so will only be seen when the bottom of content is reached. If we'd like to shrink it further, that's certainly doable, but this might be good enough. I think it'll be more natural when there's actually content.