### PR TITLE
Increase width of content area to fill screen on desktop

### DIFF
--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -13,3 +13,20 @@ h3 {
   border-bottom: 1px solid var(--pst-color-border-muted);
   line-height: 1.5em;
 }
+
+/* Make content area take up the same max width as the top navigation bar */
+.bd-main .bd-content .bd-article-container {
+  max-width: 100%; /* default is 60em */
+}
+
+/* Make the entire page area get used */
+.bd-page-width {
+  max-width: 100%; /* default is 88rem */
+}
+
+/* Make the primary sidebar only as large as it needs to be to fit its content */
+@media (min-width: 960px) {
+  .bd-sidebar-primary {
+    max-width: fit-content;
+  }
+}


### PR DESCRIPTION
## Summary
This global css change follows the instructions [in the pydata-sphinx-theme docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#horizontal-spacing) to make the article content area fill the screen. Additionally, the primary nav bar has been set to only be as large as necessary to fit its content. Here's what that looks like:

![image](https://github.com/observational-dev/oawiki/assets/14017872/c5ea3cab-76c9-47fa-9833-111d991819c4)

Resolves https://github.com/observational-dev/oawiki/issues/27.