### PR TITLE
Dropdown elements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pre-commit
 pydata-sphinx-theme
 sphinx>=7
 sphinx-design
+sphinx-togglebutton

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -30,3 +30,18 @@ h3 {
     max-width: fit-content;
   }
 }
+
+/* Question dropdown stuff */
+div.admonition.admonition-question {
+  /*border-color: hsl(0, 100%, 50%); /* YouTube red */
+}
+div.admonition.admonition-question > .admonition-title:before {
+  /*background-color: hsl(0, 99%, 18%);*/
+}
+div.admonition.admonition-question > .admonition-title:after {
+  /*color: hsl(0, 100%, 50%);*/
+  content: "\f086"; /* fa-solid fa-tv */
+}
+div.admonition.admonition-question > .admonition-title {
+  /*color: white;*/
+}

--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -32,15 +32,16 @@ h3 {
 }
 
 /* Question dropdown stuff */
+/* see https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/extending.html#combining-all-three-customizations */
 div.admonition.admonition-question {
-  /*border-color: hsl(0, 100%, 50%); /* YouTube red */
+  /*border-color: hsl(0, 100%, 50%); /* custom colors etc */
 }
 div.admonition.admonition-question > .admonition-title:before {
   /*background-color: hsl(0, 99%, 18%);*/
 }
 div.admonition.admonition-question > .admonition-title:after {
   /*color: hsl(0, 100%, 50%);*/
-  content: "\f086"; /* fa-solid fa-tv */
+  content: "\f086"; /* unicode for dialog */
 }
 div.admonition.admonition-question > .admonition-title {
   /*color: white;*/

--- a/src/conf.py
+++ b/src/conf.py
@@ -22,10 +22,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # Turn all bad references into warnings
 nitpicky = True
 
-extensions = [
-    "myst_parser",
-    "sphinx_design",
-]
+extensions = ["myst_parser", "sphinx_design", "sphinx_togglebutton"]
 
 myst_enable_extensions = [
     "amsmath",

--- a/src/imaging/examplepage.md
+++ b/src/imaging/examplepage.md
@@ -1,0 +1,61 @@
+# Example Page
+
+Rather than being intended for wiki viewers, this page exists for wiki editors. You could be one!
+
+## Markdown Examples
+
+If you've used Discord or Reddit, these might be familiar to you.
+
+**Text that is bolded**
+
+_Italicized text_
+
+~~struckthrough text~~
+
+fun `inline code` format
+
+Here is a link to the markdown we use: [Commonmark Help](https://commonmark.org/help/) and a cat image for you:
+
+![a cat yawns, Locke 2023, used with permission](https://cdn.discordapp.com/attachments/514888013533151253/1157127122570190998/PXL_20230929_012816945.PORTRAIT.jpg)
+
+> This is a blockquote. It's useful for separating out a specific chunk of text from the rest. Glass does not flow at room temperature as a high-viscosity liquid. Although glass shares some molecular properties with liquids, it is a solid at room temperature and only begins to flow at hundreds of degrees above room temperature. Old glass which is thicker at the bottom than at the top comes from the production process, not from slow flow; no such distortion is observed in other glass objects of similar or even greater age
+> _Wikipedia [List of Common Misconceptions](https://en.m.wikipedia.org/wiki/List_of_common_misconceptions)_
+
+### Other items
+
+- List
+- List
+- List
+
+Horizontal rule:
+
+---
+
+1. One
+2. Two
+3. Three
+
+```
+Code block
+Probably less used on this wiki, but included here for reference
+```
+
+## Tricks Beyond Markdown
+
+You can do some neat dropdown bits if you want:
+
+```{admonition} What is a dropdown example?
+:class: dropdown admonition-question
+
+
+It's a potentially useful feature demonstrated here!
+
+```
+
+```{admonition} Can you show a second dropdown example?
+:class: dropdown admonition-question
+
+
+Here you go!
+
+```

--- a/src/index.md
+++ b/src/index.md
@@ -24,11 +24,3 @@ Below, you can find some of the more important articles for each discipline of o
 [Discord](https://discord.gg/astronomy) | [About](https://)
 
 </center>
-
-```{admonition} What is a dropdown example?
-:class: dropdown admonition-question
-
-
-    It's a potentially useful feature demonstrated here!
-
-```

--- a/src/index.md
+++ b/src/index.md
@@ -11,9 +11,9 @@ Below, you can find some of the more important articles for each discipline of o
 
 <center>
 
-|                Visual astronomy                 |                                      Astrophotography                                       |
-| :---------------------------------------------: | :-----------------------------------------------------------------------------------------: |
-| [The Night Sky](https://) - [Targets](https://) |                    [Understanding AP](https://) - [Wide Field](https://)                    |
+|                Visual astronomy                 |                                          Astrophotography                                           |
+| :---------------------------------------------: | :-------------------------------------------------------------------------------------------------: |
+| [The Night Sky](https://) - [Targets](https://) |                        [Understanding AP](https://) - [Wide Field](https://)                        |
 | [Telescopes](https://) - [Literature](https://) | [Planetary](https://wiki.observational.space/imaging/planetary_imaging.html) - [Software](https://) |
 
 |                  Telescope making                  |                        For Beginners                         |
@@ -24,3 +24,11 @@ Below, you can find some of the more important articles for each discipline of o
 [Discord](https://discord.gg/astronomy) | [About](https://)
 
 </center>
+
+```{admonition} What is a dropdown example?
+:class: dropdown admonition-question
+
+
+    It's a potentially useful feature demonstrated here!
+
+```


### PR DESCRIPTION
This implements and demonstrates a dropdown dialog, which could be useful for FAQs or other places in the first parts of the wiki to be viewed by newcomers. I also added in an example wiki page that can be used as a starting point for others and formatting reference. I'd like to retain that even if we decide the dropdown feature is unneeded. For now it's in the imaging/ folder as I had issues putting it elsewhere.

It requires an additonal pip package, `sphinx-togglebutton`

![both dropdowns collapsed](https://cdn.discordapp.com/attachments/576849290354360323/1163468359501889566/image.png)

![one dropdown opened](https://cdn.discordapp.com/attachments/576849290354360323/1163468359896137919/image.png)

![both dropdowns opened](https://cdn.discordapp.com/attachments/576849290354360323/1163468360286220398/image.png)

