### PR TITLE
Add 404 page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pre-commit
 pydata-sphinx-theme
 sphinx>=7
 sphinx-design
+sphinx-notfound-page

--- a/src/404.md
+++ b/src/404.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+permalink: /404.html
+---
+
+# Page not found
+
+**Sorry, this page couldn't be found.**
+
+Click on the navigation bar at the top of the page to go elsewhere.

--- a/src/conf.py
+++ b/src/conf.py
@@ -25,6 +25,7 @@ nitpicky = True
 extensions = [
     "myst_parser",
     "sphinx_design",
+    "notfound.extension",
 ]
 
 myst_enable_extensions = [
@@ -66,6 +67,8 @@ html_context = {
 }
 
 html_static_path = ["_static"]
+
+notfound_urls_prefix = None
 
 
 def setup(app):

--- a/src/conf.py
+++ b/src/conf.py
@@ -68,7 +68,7 @@ html_context = {
 
 html_static_path = ["_static"]
 
-notfound_urls_prefix = None
+notfound_urls_prefix = ''
 
 
 def setup(app):


### PR DESCRIPTION
This PR adds a 404 page. Closes https://github.com/observational-dev/oawiki/issues/31.

`sphinx-notfound-page` is added as a dependency. Unfortunately this is [annoying to test locally](https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages), it's easier just to merge this and make a fix if needed. I followed the instructions on that page, so I think everything should work.