### PR TITLE
Fix table css that was affected when git history was added

### DIFF
--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -76,7 +76,7 @@ label.modal-checkbox-label:hover {
 
 /* Add a little spacing around the git history table elements */
 .git-history td,
-th {
+.git-history th {
   padding: 0.5em;
   border: 1px solid var(--pst-color-border-muted);
 }


### PR DESCRIPTION
https://github.com/observational-dev/oawiki/pull/47 broke table styles site-wide:

![image](https://github.com/observational-dev/oawiki/assets/14017872/825fb92b-a0e9-44d2-8952-abc476746823)

This rule change fixes the issue:

![image](https://github.com/observational-dev/oawiki/assets/14017872/3412ee7b-3d22-42ad-be4e-dc98f36cf308)
