### PR TITLE
Pin the pydata-sphinx-theme dependency; 0.15.1 breaks sidebar, js error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ myst-parser
 openpyxl
 pandas
 pre-commit
-pydata-sphinx-theme
+pydata-sphinx-theme==0.14.4
 sphinx>=7
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
This PR pins the `pydata-sphinx-theme` dependency. Building with `0.15.0rc0` and `0.15.1` throws a js error on page load, and the sidebar is missing: https://github.com/pydata/pydata-sphinx-theme/issues/1626